### PR TITLE
dockerize and allow the creation of standalone build of the project

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+; Do NOT set environment/host specific setttings (like registry or script-shell) here. Use ~/.npmrc
+
+; Use hoisted packages for Next.js standalone build https://pnpm.io/npmrc#node-linker
+; - Solves missing Next.js standalone build dependencies https://github.com/vercel/next.js/issues/48017
+; - Solves Next.js standalone build breaking pnpm monorepo dependencies https://github.com/vercel/next.js/issues/65636
+; - Solves Turborepo error writing to cache https://github.com/vercel/turbo/issues/6823
+;node-linker=hoisted
+shared-workspace-lockfile=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . .
 
 RUN npm install -g pnpm@latest
-RUN pnpm install && npm run build
+RUN pnpm install && pnpm run build
 
 ## temporary fix:
 #  for some reason nextjs doesn't automatically move

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
-FROM node:18-alpine
-
+FROM node:18-alpine AS builder
 WORKDIR /app
-RUN apk add neovim
-
 COPY . .
 
 RUN npm install -g pnpm@latest
 RUN pnpm install && npm run build
 
-## fixed static not being added to standalone
-#  for some reason nextjs doesn't automatically do this ?
-#  maybe the config is cooked ? :/
+## temporary fix:
+#  for some reason nextjs doesn't automatically move
+#  static folder into the standalone/build/ folder...
+#  so we do it manually here
 WORKDIR /app/interface/
 RUN cp -r ./build/static ./build/standalone/build
 
-WORKDIR /app/interface/build/standalone
+
+
+FROM node:18-alpine AS runner
+COPY --from=builder /app/interface/build/standalone /app
+WORKDIR /app
 
 ENTRYPOINT ["node"]
 CMD ["server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,15 @@ RUN pnpm install && pnpm run build
 
 ## temporary fix:
 #  for some reason nextjs doesn't automatically move
-#  static folder into the standalone/build/ folder...
+#  static folder into the standalone/.next/ folder...
 #  so we do it manually here
 WORKDIR /app/interface/
-RUN cp -r ./build/static ./build/standalone/build
+RUN cp -r ./.next/static ./.next/standalone/.next
 
 
 
 FROM node:18-alpine AS runner
-COPY --from=builder /app/interface/build/standalone /app
+COPY --from=builder /app/interface/.next/standalone /app
 WORKDIR /app
 
 ENTRYPOINT ["node"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18-alpine
+
+WORKDIR /app
+RUN apk add neovim
+
+COPY . .
+
+RUN npm install -g pnpm@latest
+RUN pnpm install && npm run build
+
+## fixed static not being added to standalone
+#  for some reason nextjs doesn't automatically do this ?
+#  maybe the config is cooked ? :/
+WORKDIR /app/interface/
+RUN cp -r ./build/static ./build/standalone/build
+
+WORKDIR /app/interface/build/standalone
+
+ENTRYPOINT ["node"]
+CMD ["server.js"]

--- a/README.md
+++ b/README.md
@@ -4,18 +4,30 @@ A web-based tool for converting images into Minecraft map-art, formatted in a va
 
 ## Usage
 
-to run the project you can install dependency and build the project by running:
-
+### setup
+to build the project for the standalone version or to run it, you can install dependency and build the project by running these command:
 ```sh
 pnpm install && pnpm run build
 ```
 
+### pnpm
 then you can serve the project by moving to the `./interface` folder, then run `npm start`
-
 ```sh
 cd ./interface
 pnpm run start
 ```
+
+### standalone
+or to use the standalone version of the project you can move the the `./interface/build/standalone` folder then run the `server.js` like so :
+```sh
+cp -r ./interface/build/static ./interface/build/standalone/build
+cd ./interface/build/standalone
+node ./server.js
+```
+> [!WARNING]
+> for some reason nextjs doesn't automatically move static folder from the build
+> folder into the `./standalone/build` folder, so be sure to add the 
+> `build/static` in to the `build/standalone/build` folder
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A web-based tool for converting images into Minecraft map-art, formatted in a variety of ways (most commonly in the `litematica` format). These schematics can then be used as a blueprint for building map-art in Minecraft.
 
+## Usage
+
+to run the project you can install dependency and build the project by running:
+
+```sh
+pnpm install && pnpm run build
+```
+
+then you can serve the project by moving to the `./interface` folder, then run `npm start`
+
+```sh
+cd ./interface
+pnpm run start
+```
+
 ## About
 
 There are already some good implementations/alternatives to this tool out in the wild, most notably being [mapartcraft](https://rebane2001.com/mapartcraft/), however I found their interfaces very clunky to work in and hard to iterate fluidly on a map-art idea. I also wanted to add features that were missing and add support for outputting in alternative data formats such as `.litematic` files for the excellent [Litematica](https://github.com/maruohon/litematica) mod.

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ to build the project for the standalone version or to run it, you can install de
 pnpm install && pnpm run build
 ```
 
-### pnpm
+#### pnpm
 then you can serve the project by moving to the `./interface` folder, then run `pnpm start`
 ```sh
 cd ./interface
 pnpm run start
 ```
 
-### standalone
+#### standalone
 or to use the standalone version of the project you can move the the `./interface/build/standalone` folder then run the `server.js` like so :
 ```sh
 cp -r ./interface/build/static ./interface/build/standalone/build
@@ -28,6 +28,14 @@ node ./server.js
 > for some reason nextjs doesn't automatically move static folder from the build
 > folder into the `./standalone/build` folder, so be sure to add the 
 > `build/static` in to the `build/standalone/build` folder
+
+### docker
+or skip everything and just deploy with docker
+```sh
+docker image rm cartographer:latest    #remove existing cartographer image
+docker build . -t cartographer:latest
+docker run --rm -p 3000:3000 --name cartographer -it cartographer:latest
+``` 
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pnpm run start
 ```
 
 #### standalone
-or to use the standalone version of the project you can move the the `./interface/build/standalone` folder then run the `server.js` like so :
+or to use the standalone version of the project you can move to the `./interface/build/standalone` folder then run the `server.js` like so :
 ```sh
 cp -r ./interface/build/static ./interface/build/standalone/build
 cd ./interface/build/standalone
@@ -27,7 +27,7 @@ node ./server.js
 > [!WARNING]
 > for some reason nextjs doesn't automatically move static folder from the build
 > folder into the `./standalone/build` folder, so be sure to add the 
-> `build/static` in to the `build/standalone/build` folder
+> `build/static` into the `build/standalone/build` folder
 
 ### docker
 or skip everything and just deploy with docker

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pnpm install && pnpm run build
 ```
 
 ### pnpm
-then you can serve the project by moving to the `./interface` folder, then run `npm start`
+then you can serve the project by moving to the `./interface` folder, then run `pnpm start`
 ```sh
 cd ./interface
 pnpm run start

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ docker build . -t cartographer:latest
 docker run --rm -p 3000:3000 --name cartographer -it cartographer:latest
 ``` 
 
+or even better, just `up` it
+
+```sh
+docker compose up -d
+```
+
 ## About
 
 There are already some good implementations/alternatives to this tool out in the wild, most notably being [mapartcraft](https://rebane2001.com/mapartcraft/), however I found their interfaces very clunky to work in and hard to iterate fluidly on a map-art idea. I also wanted to add features that were missing and add support for outputting in alternative data formats such as `.litematic` files for the excellent [Litematica](https://github.com/maruohon/litematica) mod.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  cartographer:
+    build: .
+    container_name: cartographer
+    ports:
+      - "3000:3000"

--- a/interface/next.config.js
+++ b/interface/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  distDir: 'build',
   reactStrictMode: true,
   swcMinify: true,
 

--- a/interface/next.config.js
+++ b/interface/next.config.js
@@ -1,9 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  distDir: 'build',
+  distDir: "build",
   reactStrictMode: true,
   swcMinify: true,
-
+  output: "standalone",
+  
   compiler: {
     styledComponents: true
   }

--- a/interface/next.config.js
+++ b/interface/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  distDir: "build",
   reactStrictMode: true,
   swcMinify: true,
   output: "standalone",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,8 +1,9 @@
 {
   "private": true,
   "scripts": {
+    "build:packages": "pnpm run -r --filter {../packages/**} build",
     "watch": "next dev",
-    "build": "next build",
+    "build": "pnpm build:packages && next build",
     "start": "next start"
   },
   "dependencies": {

--- a/packages/block-palettes/package.json
+++ b/packages/block-palettes/package.json
@@ -8,6 +8,6 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@cartographer/pixels": "^0.0.1"
+    "@cartographer/pixels": "workspace:*"
   }
 }

--- a/packages/generation/package.json
+++ b/packages/generation/package.json
@@ -9,8 +9,8 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@cartographer/pixels": "workspace:^",
-    "@cartographer/litematica": "workspace:^",
+    "@cartographer/pixels": "workspace:*",
+    "@cartographer/litematica": "workspace:*",
     "lodash": "^4.17.21",
     "nbt": "^0.8.1",
     "pako": "^2.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,13 +20,13 @@ importers:
   interface:
     dependencies:
       '@cartographer/block-palettes':
-        specifier: 'workspace:'
+        specifier: "workspace:*"
         version: link:../packages/block-palettes
       '@cartographer/generation':
-        specifier: 'workspace:'
+        specifier: "workspace:*"
         version: link:../packages/generation
       '@cartographer/pixels':
-        specifier: 'workspace:'
+        specifier: "workspace:*"
         version: link:../packages/pixels
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.2.1
@@ -117,10 +117,10 @@ importers:
   packages/generation:
     dependencies:
       '@cartographer/litematica':
-        specifier: workspace:^
+        specifier: "workspace:*"
         version: link:../litematica
       '@cartographer/pixels':
-        specifier: workspace:^
+        specifier: "workspace:*"
         version: link:../pixels
       lodash:
         specifier: ^4.17.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,7 @@ importers:
   packages/block-palettes:
     dependencies:
       '@cartographer/pixels':
-        specifier: ^0.0.1
+        specifier: "workspace:*"
         version: link:../pixels
 
   packages/generation:


### PR DESCRIPTION
added more documentation regarding usage and added more deployment methods to allow other to run the project more easily.

there is an issue regarding the standalone static folder not being included automatically upon build in the standalone version, the fix is quite easy tho, just copy the folder static folder from `./build` or `./.next` folder into the `standalone` folder,